### PR TITLE
chore: update python dependencies in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 asgiref==3.8.1
-Django==5.0
-pillow==11.0.0
-psycopg2-binary==2.9.10
-python-dotenv==1.0.1
-sqlparse==0.5.1
-typing_extensions==4.12.2
+Django==5.2.3
+pillow==11.2.1
+python-dotenv==1.1.1
+sqlparse==0.5.3
+typing_extensions==4.14.0


### PR DESCRIPTION
## Changes
This PR updates several Python dependencies to their latest stable versions:

### Updated Dependencies
- **Django**: 5.0 → 5.2.3
- **Pillow**: 11.0.0 → 11.2.1
- **python-dotenv**: 1.0.1 → 1.1.1
- **sqlparse**: 0.5.1 → 0.5.3
- **typing_extensions**: 4.12.2 → 4.14.0

### Removed Dependencies
- psycopg2-binary (not needed - Only required for PostgreSQL)